### PR TITLE
Added option to open research-links in a new tab

### DIFF
--- a/app/Template/AdminTemplate.php
+++ b/app/Template/AdminTemplate.php
@@ -113,6 +113,20 @@ class AdminTemplate extends FancyResearchLinksClass {
 				</div>
 			<?php endforeach; ?>
 			<div class="form-group col-sm-12">
+				<span class="h3"><?= I18N::translate('Open links') ?></span> <br>
+				<label class="checkbox-inline">
+					<?php 
+						if ($this->getSetting('FRL_DEFAULT_BLANK') === '1') {
+							$blank_enabled = '1';
+						} else {
+							$blank_enabled = '0';
+						}
+					?>
+					<?= FunctionsEdit::twoStateCheckbox('FRL_DEFAULT_BLANK', $blank_enabled) ?> <?= I18N::translate('In a new tab') ?>
+				</label>
+				<p class="small"><?= I18N::translate('Open the researchlinks in a new tab(target="blank")?') ?></p>
+			</div>	
+			<div class="form-group col-sm-12">
 				<button type="submit" class="btn btn-primary">
 					<i class="fa fa-check"></i>
 					<?= I18N::translate('save') ?>

--- a/module.php
+++ b/module.php
@@ -84,6 +84,7 @@ class FancyResearchLinksModule extends AbstractModule implements ModuleConfigInt
 				if (Filter::postBool('save')) {
 					$this->setSetting('FRL_PLUGINS', serialize(Filter::post('NEW_FRL_PLUGINS')));
 					$this->setSetting('FRL_DEFAULT_AREA', Filter::post('FRL_DEFAULT_AREA'));
+					$this->setSetting('FRL_DEFAULT_BLANK', Filter::post('FRL_DEFAULT_BLANK'));
 					Log::addConfigurationLog($this->getTitle() . ' config updated');
 				}
 				$template = new AdminTemplate;
@@ -214,9 +215,14 @@ class FancyResearchLinksModule extends AbstractModule implements ModuleConfigInt
 									];
 									$link		 = $plugin->createLink($this->module()->getNames($this->primary, $this->attrs, $plugin->encodePlus()));
 								}
+								if ($this->getSetting('FRL_DEFAULT_BLANK') === '1') {
+									$target = 'target="_blank"';
+								} else {
+									$target = '';
+								}
 								$html .=
 									'<li>' .
-									'<a href="' . Filter::escapeHtml($link) . '">' .
+									'<a ' . $target . ' href="' . Filter::escapeHtml($link) . '">' .
 									$plugin->getPluginName() .
 									'</a>' .
 									'</li>';


### PR DESCRIPTION
Hi,
I noticed that clicking on a researchlink steered you away from the page you were on. I've added a config option you can set so you can decide if a link is opened in a new tab (target="_blank").
